### PR TITLE
Use docopt for CLI arg parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 
 [dependencies]
+docopt = "0.6.81"
 emailaddress = "0.3.0"
 hyper = "0.9.6"
 iron = "0.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,34 +1,60 @@
+extern crate docopt;
 extern crate iron;
 extern crate ladaemon;
-
 #[macro_use(router)]
 extern crate router;
+extern crate rustc_serialize;
 
+use docopt::Docopt;
 use iron::Iron;
-use std::env;
-use std::io::{self, Write};
+use std::str::FromStr;
 
 
-/// The `main()` method. Will loop forever to serve HTTP requests.
+/// Defines the program's version, as set by Cargo at compile time.
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+
+/// Defines the program's usage string.
+///
+/// [Docopt](http://docopt.org) parses this and generates a custom argv parser.
+const USAGE: &'static str = r#"
+Let's Auth.
+
+Usage:
+  ladaemon [options] CONFIG
+  ladaemon --version
+  ladaemon --help
+
+Options:
+  --address=<ip>  Address to listen on [default: 127.0.0.1]
+  --port=<port>   Port to listen on [default: 3333]
+  --version       Print version information and exit
+  --help          Print this help message and exit
+"#;
+
+
+/// Holds parsed command line parameters.
+#[derive(RustcDecodable)]
+#[allow(non_snake_case)]
+struct Args {
+    arg_CONFIG: String,
+    flag_address: String,
+    flag_port: u16,
+}
+
+
+/// Starts the server.
 fn main() {
+    let args: Args = Docopt::new(USAGE)
+                         .and_then(|d| d.version(Some(VERSION.to_string())).decode())
+                         .unwrap_or_else(|e| e.exit());
 
-    // Make sure we get a file name where we can find configuration.
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        io::stderr().write(b"no configuration file specified\n").unwrap();
-        return;
-    }
+    let app = ladaemon::AppConfig::from_json_file(&args.arg_CONFIG);
 
-    // Read the configuration from the provided file.
-    let app = ladaemon::AppConfig::from_json_file(&args[1]);
-
-    // Register all handlers with a router object. TODO: cloning the
-    // configuration object is kind of ugly, but is apparently needed with
-    // the way the Iron `Handler` trait is defined. Also, it would be cleaner
-    // if the handlers could just be a function, instead of single-method
-    // impls.
+    // TODO: Cloning the configuration object is ugly, but apparently necessary
+    // with how the Iron `Handler` trait is defined. Also, it would be cleaner
+    // if the handlers could just be functions, instead of single-method impls.
     let router = router!{
-
         // Human-targeted endpoints
         get "/" => ladaemon::WelcomeHandler { app: app.clone() },
         get "/confirm" => ladaemon::ConfirmHandler { app: app.clone() },
@@ -41,12 +67,12 @@ fn main() {
 
         // OpenID Connect relying party endpoints
         get "/callback" => ladaemon::CallbackHandler { app: app.clone() },
-
     };
 
-    // Iron will take care of stuff from here. It should spin up a number of
-    // threads according to the number of cores available. TODO: make the
-    // interface on which we listen configurable.
-    Iron::new(router).http("0.0.0.0:3333").unwrap();
+    let ip_address = std::net::IpAddr::from_str(&args.flag_address).unwrap();
+    let socket = std::net::SocketAddr::new(ip_address, args.flag_port);
 
+    println!("Listening on http://{}", socket);
+
+    Iron::new(router).http(socket).unwrap();
 }


### PR DESCRIPTION
I also trimmed down the comments in main.rs, since things seem sufficiently declarative now that we've got the `router!` macro in place.