### PR TITLE
Docopt round 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 
 [dependencies]
+docopt = "0.6.81"
 emailaddress = "0.3.0"
 hyper = "0.9.6"
 iron = "0.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,51 @@
+extern crate docopt;
 extern crate iron;
 extern crate ladaemon;
-
 #[macro_use(router)]
 extern crate router;
+extern crate rustc_serialize;
 
+use docopt::Docopt;
 use iron::Iron;
-use std::env;
-use std::io::{self, Write};
+
+
+/// Defines the program's version, as set by Cargo at compile time.
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+
+/// Defines the program's usage string.
+///
+/// [Docopt](http://docopt.org) parses this and generates a custom argv parser.
+const USAGE: &'static str = r#"
+Let's Auth.
+
+Usage:
+  ladaemon CONFIG
+  ladaemon --version
+  ladaemon --help
+
+Options:
+  --version       Print version information and exit
+  --help          Print this help message and exit
+"#;
+
+
+/// Holds parsed command line parameters.
+#[derive(RustcDecodable)]
+#[allow(non_snake_case)]
+struct Args {
+    arg_CONFIG: String,
+}
 
 
 /// The `main()` method. Will loop forever to serve HTTP requests.
 fn main() {
-
-    // Make sure we get a file name where we can find configuration.
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        io::stderr().write(b"no configuration file specified\n").unwrap();
-        return;
-    }
+    let args: Args = Docopt::new(USAGE)
+                         .and_then(|d| d.version(Some(VERSION.to_string())).decode())
+                         .unwrap_or_else(|e| e.exit());
 
     // Read the configuration from the provided file.
-    let app = ladaemon::AppConfig::from_json_file(&args[1]);
+    let app = ladaemon::AppConfig::from_json_file(&args.arg_CONFIG);
 
     // Register all handlers with a router object. TODO: cloning the
     // configuration object is kind of ugly, but is apparently needed with
@@ -48,5 +73,4 @@ fn main() {
     // threads according to the number of cores available. TODO: make the
     // interface on which we listen configurable.
     Iron::new(router).http("0.0.0.0:3333").unwrap();
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ extern crate rustc_serialize;
 
 use docopt::Docopt;
 use iron::Iron;
+use std::str::FromStr;
 
 
 /// Defines the program's version, as set by Cargo at compile time.
@@ -20,11 +21,13 @@ const USAGE: &'static str = r#"
 Let's Auth.
 
 Usage:
-  ladaemon CONFIG
+  ladaemon [options] CONFIG
   ladaemon --version
   ladaemon --help
 
 Options:
+  --address=<ip>  Address to listen on [default: 127.0.0.1]
+  --port=<port>   Port to listen on [default: 3333]
   --version       Print version information and exit
   --help          Print this help message and exit
 "#;
@@ -35,6 +38,8 @@ Options:
 #[allow(non_snake_case)]
 struct Args {
     arg_CONFIG: String,
+    flag_address: String,
+    flag_port: u16,
 }
 
 
@@ -69,8 +74,10 @@ fn main() {
 
     };
 
-    // Iron will take care of stuff from here. It should spin up a number of
-    // threads according to the number of cores available. TODO: make the
-    // interface on which we listen configurable.
+    let ip_address = std::net::IpAddr::from_str(&args.flag_address).unwrap();
+    let socket = std::net::SocketAddr::new(ip_address, args.flag_port);
+
+    println!("Listening on http://{}", socket);
+
     Iron::new(router).http("0.0.0.0:3333").unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,13 +52,10 @@ fn main() {
     // Read the configuration from the provided file.
     let app = ladaemon::AppConfig::from_json_file(&args.arg_CONFIG);
 
-    // Register all handlers with a router object. TODO: cloning the
-    // configuration object is kind of ugly, but is apparently needed with
-    // the way the Iron `Handler` trait is defined. Also, it would be cleaner
-    // if the handlers could just be a function, instead of single-method
-    // impls.
+    // TODO: cloning the configuration object is ugly, but apparently necessary
+    // with how the Iron `Handler` trait is defined. Also, it would be cleaner
+    // if the handlers could just be functions, instead of single-method impls.
     let router = router!{
-
         // Human-targeted endpoints
         get "/" => ladaemon::WelcomeHandler { app: app.clone() },
         get "/confirm" => ladaemon::ConfirmHandler { app: app.clone() },
@@ -71,7 +68,6 @@ fn main() {
 
         // OpenID Connect relying party endpoints
         get "/callback" => ladaemon::CallbackHandler { app: app.clone() },
-
     };
 
     let ip_address = std::net::IpAddr::from_str(&args.flag_address).unwrap();


### PR DESCRIPTION
The `d.version(Some(VERSION.to_string()))` function automatically implements handling `--version`, and takes an `Option<String>`, so we have to convert `VERSION`, a `&'static str` before passing it.